### PR TITLE
Add custom 'arefeen' domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+aleeza.arefeen.me

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Personal Website
 ### A responsive personal website created using HTML, CSS, and Javascript. Used the following video for guidance: https://www.youtube.com/watch?v=27JtRAI3QO8
-### Currently launched at https://aleezaarefeen.github.io/
+### Currently launched at https://aleeza.arefeen.me/


### PR DESCRIPTION
I recently acquired the `arefeen.me` domain which means we can use domains like [amar.arefeen.me](https://amar.arefeen.me/), etc. 

If you'd like, by making the proposed changes you should be able to access your personal website using [aleeza.arefeen.me](https://aleeza.arefeen.me/) (in addition to the default [aleezaarefeen.github.io](https://aleezaarefeen.github.io))

If you find a more interesting one (aleeza.ca? aleeza.bio?) from the (e.g.) [GitHub education pack](https://education.github.com/pack/offers) offers, feel free to set that up for yourself instead.